### PR TITLE
Update ChangeVisuallyAttribute.cs

### DIFF
--- a/MvcMegaForms/MvcMega.Forms/DataAnnotations/ChangeVisuallyAttribute.cs
+++ b/MvcMegaForms/MvcMega.Forms/DataAnnotations/ChangeVisuallyAttribute.cs
@@ -42,13 +42,14 @@ namespace MvcMega.Forms.DataAnnotations
             NotContains,
         }
 
-        public ChangeVisuallyAttribute(ChangeTo to, string whenOtherPropertyName, DisplayChangeIf ifOperator, object value, bool conditionPassesIfNull)
+        public ChangeVisuallyAttribute(ChangeTo to, string whenOtherPropertyName, DisplayChangeIf ifOperator, object value, bool conditionPassesIfNull, ComparisonValueType valueType = ComparisonValueType.String)
         {
             To = to;
             WhenOtherPropertyName = whenOtherPropertyName;
             If = ifOperator;
             Value = value;
             ConditionPassesIfNull = conditionPassesIfNull;
+            ValueTypeToCompare = valueType;
         }
 
         public enum ComparisonValueType


### PR DESCRIPTION
String coercion on compare due to missing ComparisonValueType. This leads to e.g. (1, 10, 11, 2, 3, 4)
